### PR TITLE
Fixed detect script

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -13,3 +13,6 @@ if [[ ! -f "${BUILD_DIR}/.slug-post-clean" ]]; then
   echo "Could not find .slug-post-clean file - exiting"
   exit 1
 fi
+
+echo "POST BUILD CLEAN"
+exit 0


### PR DESCRIPTION
Fixed #1, added `echo "POST BUILD CLEAN"` and `exit 0` to detect script
